### PR TITLE
[22884] Multiple outputs logic with restriction of models

### DIFF
--- a/ml_model_metadata_node.py
+++ b/ml_model_metadata_node.py
@@ -71,6 +71,10 @@ def task_callback(user_input, node_status, ml_model_metadata):
         extra_data_str = ''.join(chr(b) for b in extra_data_bytes)
         extra_data_dict = json.loads(extra_data_str)
 
+        if "model_restrains" in extra_data_dict:
+            encoded_data = json.dumps({"model_restrains": extra_data_dict["model_restrains"]}).encode("utf-8")
+            ml_model_metadata.extra_data(encoded_data)
+
         if "model_selected" in extra_data_dict and extra_data_dict["model_selected"] != "":
             encoded_data = json.dumps({"model_selected": extra_data_dict["model_selected"]}).encode("utf-8")
             ml_model_metadata.extra_data(encoded_data)

--- a/ml_model_provider_node.py
+++ b/ml_model_provider_node.py
@@ -59,10 +59,15 @@ def task_callback(ml_model_metadata,
         try:
             chosen_model = None
             # Model restriction after various outputs
+            restrained_models = []
             extra_data_bytes = ml_model_metadata.extra_data()
             if extra_data_bytes:
                 extra_data_str = ''.join(chr(b) for b in extra_data_bytes)
                 extra_data_dict = json.loads(extra_data_str)
+                if "model_restrains" in extra_data_dict:
+                    restrained_models = extra_data_dict["model_restrains"]
+                    print("Restrained models:", restrained_models)  #debugging
+
                 if "model_selected" in extra_data_dict:
                     chosen_model = extra_data_dict["model_selected"]
                     print("Selected model:", chosen_model)  ##debugging
@@ -86,8 +91,11 @@ def task_callback(ml_model_metadata,
                         model_use  =  "openai-community/gpt2"
                     if(str(model_use) == "mlx-community/Llama-3.2-1B-Instruct-4bit"):
                         model_use  =  "openai-community/gpt2-medium"
-                    chosen_model = model_use
-                    break
+                    if str(model_use) not in restrained_models:
+                        chosen_model = model_use
+                        break
+                    else:
+                        print(f"Chosen model: {model_use} is restrained. Choosing the next model.")
 
             print(f"")    #Debugging
             print(f"Chosen model: {chosen_model}")    #Debugging


### PR DESCRIPTION
This PR add the logic to restrain previous selected models when multiple outputs are requested.

Goes after #6 